### PR TITLE
fixed empty context in call to NewRemoteAllocator

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -162,7 +162,7 @@ func (c *Client) doRequestChrome(req *Request) (*Response, error) {
 	var ctx context.Context
 	var cancel context.CancelFunc
 	if c.opt.RemoteAllocatorURL != "" {
-		ctx, cancel = chromedp.NewRemoteAllocator(ctx, c.opt.RemoteAllocatorURL)
+		ctx, cancel = chromedp.NewRemoteAllocator(context.Background(), c.opt.RemoteAllocatorURL)
 	} else {
 		ctx, cancel = chromedp.NewExecAllocator(context.Background(), c.opt.AllocatorOptions...)
 	}


### PR DESCRIPTION
The refactoring made in #https://github.com/geziyor/geziyor/commit/7a76a9b95ed27059c55fd3f1635d4b915210b628#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L173 has introduced a bug which causes **geziyor** to panic whenever `GetRendered` method is used in combination with `BrowserEndpoint` option, like this:
```golang
geziyor.NewGeziyor(&geziyor.Options{
    StartRequestsFunc: func(g *geziyor.Geziyor) {
        g.GetRendered("https://httpbin.org/anything", g.Opt.ParseFunc)
    },
    ParseFunc: func(g *geziyor.Geziyor, r *client.Response) {
        fmt.Println(string(r.Body))
    },
    BrowserEndpoint: "ws://localhost:9222",
}).Start()
```
Crash output:
```console
Scraping Started
cannot create context from nil parent goroutine 9 [running]:
runtime/debug.Stack(0x14000121a68, 0x104a06e80, 0x104ae7a50)
        /Users/albert/sdk/go1.16.6/src/runtime/debug/stack.go:24 +0x88
github.com/geziyor/geziyor.(*Geziyor).recoverMe(0x14000123540)
        /Users/albert/go/pkg/mod/github.com/geziyor/geziyor@v0.0.0-20210530074354-d3bdaf624012/geziyor.go:310 +0x50
panic(0x104a06e80, 0x104ae7a50)
        /Users/albert/sdk/go1.16.6/src/runtime/panic.go:965 +0x14c
context.WithCancel(0x0, 0x0, 0x8, 0x140000b8020, 0x14000090000)
        /Users/albert/sdk/go1.16.6/src/context/context.go:234 +0x150
github.com/chromedp/chromedp.NewRemoteAllocator(0x0, 0x0, 0x1049037e5, 0x17, 0x14000121da8, 0x140000ae1b0, 0xb)
        /Users/albert/go/pkg/mod/github.com/chromedp/chromedp@v0.7.4/allocate.go:505 +0x30
github.com/geziyor/geziyor/client.(*Client).doRequestChrome(0x14000033540, 0x14000044540, 0x0, 0x0, 0x0)
        /Users/albert/go/pkg/mod/github.com/geziyor/geziyor@v0.0.0-20210530074354-d3bdaf624012/client/client.go:165 +0x90
github.com/geziyor/geziyor/client.(*Client).DoRequest(0x14000033540, 0x14000044540, 0x0, 0x0, 0x0)
        /Users/albert/go/pkg/mod/github.com/geziyor/geziyor@v0.0.0-20210530074354-d3bdaf624012/client/client.go:84 +0x38
github.com/geziyor/geziyor.(*Geziyor).do(0x14000123540, 0x14000044540, 0x104ae6bd0)
        /Users/albert/go/pkg/mod/github.com/geziyor/geziyor@v0.0.0-20210530074354-d3bdaf624012/geziyor.go:249 +0x130
created by github.com/geziyor/geziyor.(*Geziyor).Do
        /Users/albert/go/pkg/mod/github.com/geziyor/geziyor@v0.0.0-20210530074354-d3bdaf624012/geziyor.go:231 +0x98

Scraping Finished

```

The issue is that `NewRemoteAllocator` is being called with nil `ctx` argument.
https://github.com/geziyor/geziyor/blob/d3bdaf6240124135397ae8ebaa08378ea1901a31/client/client.go#L162-L165
The fix is to call it with `context.Background()` instead.