### PR TITLE
Fix HTTP2 support fix #43

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -68,6 +68,7 @@ func NewClient(opt *Options) *Client {
 				KeepAlive: 30 * time.Second,
 				DualStack: true,
 			}).DialContext,
+			ForceAttemptHTTP2:     true,
 			MaxIdleConns:          0,    // Default: 100
 			MaxIdleConnsPerHost:   1000, // Default: 2
 			IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
From official code comment:
```
	// ForceAttemptHTTP2 controls whether HTTP/2 is enabled when a non-zero
	// Dial, DialTLS, or DialContext func or TLSClientConfig is provided.
	// By default, use of any those fields conservatively disables HTTP/2.
	// To use a custom dialer or TLS config and still attempt HTTP/2
	// upgrades, set this to true.
```