### PR TITLE
Queue performance enhancements + delay middleware fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/chromedp/cdproto v0.0.0-20210713064928-7d28b402946a
 	github.com/chromedp/chromedp v0.7.4
-	github.com/elazarl/goproxy v0.0.0-20210801061803-8e322dfb79c4 // indirect
+	github.com/elazarl/goproxy v0.0.0-20210801061803-8e322dfb79c4
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/go-kit/kit v0.8.0
 	github.com/golang/snappy v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elazarl/goproxy v0.0.0-20210801061803-8e322dfb79c4 h1:lS3P5Nw3oPO05Lk2gFiYUOL3QPaH+fRoI1wFOc4G1UY=
 github.com/elazarl/goproxy v0.0.0-20210801061803-8e322dfb79c4/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=

--- a/middleware/delay.go
+++ b/middleware/delay.go
@@ -23,7 +23,7 @@ func (a *delay) ProcessRequest(r *client.Request) {
 	if a.requestDelayRandomize {
 		min := float64(a.requestDelay) * 0.5
 		max := float64(a.requestDelay) * 1.5
-		time.Sleep(time.Duration(rand.Intn(int(max-min)) + int(min)))
+		time.Sleep(a.requestDelay + time.Duration(rand.Intn(int(max-min))+int(min)))
 	} else {
 		time.Sleep(a.requestDelay)
 	}


### PR DESCRIPTION
Enhances the queue logic to improve memory management and handle deadlock situations

- Fixes delay middleware to always factor in delay if randomised delay is added (combined, not instead of)
- Moves request middleware to prior to the core g.do func - this allows middleware to cancel requests within triggering the semaphore locks (and corresponding rate limits!), also avoids queuing items that will only be cancelled, saving memory.
- Avoids deadlocks when the queue exceeds the max queue size, discards any new records and prints a message to the log