### PR TITLE
Add a generic in-memory counter and expose Metrics

### DIFF
--- a/geziyor.go
+++ b/geziyor.go
@@ -25,7 +25,7 @@ type Geziyor struct {
 	Client  *client.Client
 	Exports chan interface{}
 
-	metrics        *metrics.Metrics
+	Metrics        *metrics.Metrics
 	reqMiddlewares []middleware.RequestProcessor
 	resMiddlewares []middleware.ResponseProcessor
 	rateLimiter    *rate.Limiter
@@ -70,7 +70,7 @@ func NewGeziyor(opt *Options) *Geziyor {
 			&middleware.ParseHTML{ParseHTMLDisabled: opt.ParseHTMLDisabled},
 			&middleware.LogStats{LogDisabled: opt.LogDisabled},
 		},
-		metrics: metrics.NewMetrics(opt.MetricsType),
+		Metrics: metrics.NewMetrics(opt.MetricsType),
 	}
 
 	// Client
@@ -116,11 +116,11 @@ func NewGeziyor(opt *Options) *Geziyor {
 	}
 
 	// Base Middlewares
-	metricsMiddleware := &middleware.Metrics{Metrics: geziyor.metrics}
+	metricsMiddleware := &middleware.Metrics{Metrics: geziyor.Metrics}
 	geziyor.reqMiddlewares = append(geziyor.reqMiddlewares, metricsMiddleware)
 	geziyor.resMiddlewares = append(geziyor.resMiddlewares, metricsMiddleware)
 
-	robotsMiddleware := middleware.NewRobotsTxt(geziyor.Client, geziyor.metrics, opt.RobotsTxtDisabled)
+	robotsMiddleware := middleware.NewRobotsTxt(geziyor.Client, geziyor.Metrics, opt.RobotsTxtDisabled)
 	geziyor.reqMiddlewares = append(geziyor.reqMiddlewares, robotsMiddleware)
 
 	// Custom Middlewares
@@ -304,7 +304,7 @@ func (g *Geziyor) releaseSem(req *client.Request) {
 func (g *Geziyor) recoverMe() {
 	if r := recover(); r != nil {
 		internal.Logger.Println(r, string(debug.Stack()))
-		g.metrics.PanicCounter.Add(1)
+		g.Metrics.PanicCounter.Add(1)
 	}
 }
 

--- a/geziyor_test.go
+++ b/geziyor_test.go
@@ -389,7 +389,7 @@ func BenchmarkWhole(b *testing.B) {
 				})
 			},
 			Exporters: []export.Exporter{&export.CSV{}},
-			//MetricsType: metrics.Prometheus,
+			//MetricsType: Metrics.Prometheus,
 			LogDisabled: true,
 		}).Start()
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/discard"
 	"github.com/go-kit/kit/metrics/expvar"
+	"github.com/go-kit/kit/metrics/generic"
 	"github.com/go-kit/kit/metrics/prometheus"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -22,6 +23,9 @@ const (
 
 	// ExpVar uses built-in expvar package
 	ExpVar
+
+	// Generic uses an in-memory counter for metrics
+	Generic
 )
 
 // Metrics type stores metrics
@@ -37,6 +41,15 @@ type Metrics struct {
 // NewMetrics creates new metrics with given metrics.Type
 func NewMetrics(metricsType Type) *Metrics {
 	switch metricsType {
+	case Generic:
+		return &Metrics{
+			RequestCounter:            generic.NewCounter("request_count"),
+			ResponseCounter:           generic.NewCounter("response_count"),
+			PanicCounter:              generic.NewCounter("panic_count"),
+			RobotsTxtRequestCounter:   generic.NewCounter("robotstxt_request_count"),
+			RobotsTxtResponseCounter:  generic.NewCounter("robotstxt_response_count"),
+			RobotsTxtForbiddenCounter: generic.NewCounter("robotstxt_forbidden_count"),
+		}
 	case Discard:
 		return &Metrics{
 			RequestCounter:            discard.NewCounter(),

--- a/options.go
+++ b/options.go
@@ -62,7 +62,7 @@ type Options struct {
 	// Maximum redirection time. Default: 10
 	MaxRedirect int
 
-	// Scraper metrics exporting type. See metrics.Type
+	// Scraper Metrics exporting type. See metrics.Type
 	MetricsType metrics.Type
 
 	// ParseFunc is callback of StartURLs response.


### PR DESCRIPTION
Added a Generic metrics counter (in-memory) and also exposed the Metrics variable so that it can be used outside of external metrics counters.

(This is more of a suggestion, I'm otherwise counting manually but it doesn't make sense when it's built in!)