### PR TITLE
PrettyPrint should conform to Exporter interface

### DIFF
--- a/export/pprint.go
+++ b/export/pprint.go
@@ -9,7 +9,7 @@ import (
 type PrettyPrint struct{}
 
 // Export logs exported data to console as pretty printed
-func (*PrettyPrint) Export(exports chan interface{}) {
+func (*PrettyPrint) Export(exports chan interface{}) error {
 	for res := range exports {
 		dat, err := json.MarshalIndent(res, "", "  ")
 		if err != nil {
@@ -17,4 +17,5 @@ func (*PrettyPrint) Export(exports chan interface{}) {
 		}
 		fmt.Println(string(dat))
 	}
+	return nil
 }


### PR DESCRIPTION
`(*PrettyPrint) Export()` needs to return error in order to conform to the `Exporter` interface and be used as an exporter. Without this change, trying to use the PrettyPrint exporter results in this compile error:

````
cannot use &export.PrettyPrint{} (value of type *export.PrettyPrint) as type export.Exporter in array or slice literal:
        *export.PrettyPrint does not implement export.Exporter (wrong type for Export method)
                have Export(exports chan interface{})
                want Export(exports chan interface{}) error
````