### PR TITLE
Expose chromedp ExecAllocatorOption to the client

### DIFF
--- a/geziyor.go
+++ b/geziyor.go
@@ -73,6 +73,8 @@ func NewGeziyor(opt *Options) *Geziyor {
 		metrics: metrics.NewMetrics(opt.MetricsType),
 	}
 
+	allocatorOptions := append(chromedp.DefaultExecAllocatorOptions[:], opt.AllocatorOptions...)
+
 	// Client
 	geziyor.Client = client.NewClient(&client.Options{
 		MaxBodySize:           opt.MaxBodySize,
@@ -80,7 +82,7 @@ func NewGeziyor(opt *Options) *Geziyor {
 		RetryTimes:            opt.RetryTimes,
 		RetryHTTPCodes:        opt.RetryHTTPCodes,
 		RemoteAllocatorURL:    opt.BrowserEndpoint,
-		AllocatorOptions:      chromedp.DefaultExecAllocatorOptions[:],
+		AllocatorOptions:      allocatorOptions,
 		ProxyFunc:             opt.ProxyFunc,
 		PreActions:            opt.PreActions,
 	})

--- a/options.go
+++ b/options.go
@@ -1,15 +1,16 @@
 package geziyor
 
 import (
+	"net/http"
+	"net/url"
+	"time"
+
 	"github.com/chromedp/chromedp"
 	"github.com/geziyor/geziyor/cache"
 	"github.com/geziyor/geziyor/client"
 	"github.com/geziyor/geziyor/export"
 	"github.com/geziyor/geziyor/metrics"
 	"github.com/geziyor/geziyor/middleware"
-	"net/http"
-	"net/url"
-	"time"
 )
 
 // Options is custom options type for Geziyor
@@ -79,6 +80,10 @@ type Options struct {
 	// And you'll need to handle all rendered actions, like navigation, waiting, response etc.
 	// If you need to make custom actions in addition to the defaults, use Request.Actions instead of this.
 	PreActions []chromedp.Action
+
+	// Pass additional custom chromedp ExecAllocatorOptions.
+	// These are applied in addition to the DefaultExecAllocatorOptions.
+	AllocatorOptions []chromedp.ExecAllocatorOption
 
 	// Request delays
 	RequestDelay time.Duration


### PR DESCRIPTION
This allows the user to specify custom `chromedp.ExecAllocatorOption`. These options can be used to pass additional flags to chromedp, such as proxy settings or headless configuration.

For example, this enables using a proxy with chromedp, which is particularly useful since the existing `ProxyFunc` option is not applied to `Rendered` requests:

```go
geziyor.NewGeziyor(&geziyor.Options{
  AllocatorOptions: []chromedp.ExecAllocatorOption{
	  chromedp.ProxyServer("socks5://..."),
  },
}
```